### PR TITLE
[WP-916] catch case when register_block_type func is not defined

### DIFF
--- a/includes/render/class-linked-image-reusable-block.php
+++ b/includes/render/class-linked-image-reusable-block.php
@@ -50,7 +50,7 @@ class LinkedImageReusableBlock extends ReusableBlock {
         $dashed_code_name =  str_replace('_', '-', $this->code_name);
 		return "
 <!-- wp:image -->
-	<figure class=\"wp-block-image figure_$class_name fixed-size-linked-img\"><a href=\"$escaped_link\"><img src=\"$escaped_image\" alt=\"link to $escaped_readable_name\"/></a></figure>
+	<figure class=\"wp-block-image figure_$class_name fixed-size-linked-img\"><a href=\"$escaped_link\"><img style=\"width: 32px; height: 32px;\" src=\"$escaped_image\" alt=\"link to $escaped_readable_name\"/></a></figure>
 <!-- /wp:image -->";
 	}
 

--- a/includes/render/class-reusable-block.php
+++ b/includes/render/class-reusable-block.php
@@ -45,6 +45,9 @@ abstract class ReusableBlock extends Renderer {
 					$title
 				)
 			) );
+            if ( ! function_exists('register_block_style' ) ) {
+                return;
+            }
             register_block_style(
                 'core/image',
                 array(

--- a/includes/render/class-reusable-block.php
+++ b/includes/render/class-reusable-block.php
@@ -45,17 +45,6 @@ abstract class ReusableBlock extends Renderer {
 					$title
 				)
 			) );
-            if ( ! function_exists('register_block_style' ) ) {
-                return;
-            }
-            register_block_style(
-                'core/image',
-                array(
-                    'name'         => 'fixed-size-linked-img',
-                    'label'        => 'image',
-                    'inline_style' => 'img { height:32px; width: 32px; }'
-                )
-            );
 		}
 	}
 


### PR DESCRIPTION
Some of the templates were throwing 500 with Business Profile Render plugin active
error log [here](https://console.cloud.google.com/logs/viewer?project=wsp-services&resource=k8s_container%2Fcluster_name%2Fwsp-prod-usc1f%2Fnamespace_name%2Fwsp-prod&minLogLevel=0&expandAll=false&timestamp=2020-07-30T15%3A00%3A09.412000000Z&customFacets&limitCustomFacetWidth=true&dateRangeStart=2020-07-30T14%3A00%3A10.900Z&dateRangeEnd=2020-07-30T15%3A00%3A10.900Z&interval=PT1H&scrollTimestamp=2020-07-30T14%3A08%3A50.624537248Z&filters=text%3Ae09b29d56267aa2d97a09f50c88c463b11f03ba347b1db9d366f79ec4193d961&logName=projects%2Fwsp-services%2Flogs%2Fphp-cgi&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22wsp-services%22%0Aresource.labels.location%3D%22us-central1-f%22%0Aresource.labels.container_name%3D%22php-cgi%22%0Aresource.labels.pod_name%3D%22php-cgi-deployment-0-d5f5b6c8-xtxdc%22%0Aresource.labels.namespace_name%3D%22wsp-prod%22%0Aresource.labels.cluster_name%3D%22wsp-prod-usc1f%22%0Atimestamp%3D%222020-07-30T14%3A08%3A50.624537248Z%22%0AinsertId%3D%221vpqz8sg1dl967c%22)

This is because the function register_block_type is supported for WP version >= 5.0.0, so we'd need to add a check to see if function is defined.
I added inline styling directly on the html component so that any site with an older WP version still have the same inline styling displayed. Got rid of the function call.

Replaced the plugin in one of the errored template (https://learning-management-systems-lms.websitepro.hosting/), and it seems to be working again.
@vendasta/colonelpanic