### PR TITLE
WP-868: add a link to the row meta on the plugin screen which takes users to the plugin usage page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0]
+
+### Added
+
+- a link to the row meta on the plugin screen which takes users to the plugin usage page.
+
 ## [1.1.0]
 
 ### Added

--- a/business-profile-render.php
+++ b/business-profile-render.php
@@ -3,7 +3,7 @@
  * Plugin Name: Business Profile Render
  * Plugin URI: https://github.com/vendasta/business-profile-render/
  * Description: Tool to provide utilities for displaying synchronized business profile data
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Website Pro Team
  * Author URI: https://github.com/vendasta/
  * License:

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -135,6 +135,7 @@ class Controller {
 	public function add_admin_tab_action(): void {
 		add_action( 'admin_menu', array( $this, 'add_admin_tab' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_instruction_styles' ) );
+		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 	}
 
 	/**
@@ -171,5 +172,27 @@ and reusable <a href='https://wordpress.org/support/article/blocks/'>Blocks</a>.
 	 */
 	public function add_admin_instruction_styles(): void {
 		wp_enqueue_style( 'admin-styles', BUSINESS_PROFILE_RENDER_WEB_PATH_PUBLIC . '/styles/admin-instruction.css' );
+	}
+
+	/**
+	 * Show row meta on the plugin screen.
+	 *
+	 * @param mixed $links Plugin Row Meta.
+	 * @param mixed $file  Plugin Base file.
+	 *
+	 * @return array
+	 */
+	public function plugin_row_meta( $links, $file ) {
+		if ( BUSINESS_PROFILE_RENDER_PLUGIN_FILE !== $file ) {
+			return (array) $links;
+		}
+
+		$href = esc_url( admin_url( 'tools.php?page=businessprofilerender' ) );
+		$aria_label = esc_attr__( 'View plugin usage', 'businessprofilerender' );
+		$label = esc_html__( 'Usage', 'businessprofilerender' );
+		$meta = array(
+			'usage' => "<a href=\"$href\" aria-label=\"$aria_label\">$label</a>"
+		);
+		return array_merge( $links, $meta );
 	}
 }


### PR DESCRIPTION
@vendasta/colonelpanic 
![Screen Shot 2020-08-06 at 2 00 18 PM](https://user-images.githubusercontent.com/16546500/89576934-2ff49300-d7ed-11ea-8069-43c96c800ee8.png)
