### PR TITLE
[WP-967] Add shortcode & reusable block for business contact email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.3.0]
+
+### Added
+
+- short code and reusable block for business contact email.
+
 ## [1.2.0]
 
 ### Added

--- a/business-profile-render.php
+++ b/business-profile-render.php
@@ -3,7 +3,7 @@
  * Plugin Name: Business Profile Render
  * Plugin URI: https://github.com/vendasta/business-profile-render/
  * Description: Tool to provide utilities for displaying synchronized business profile data
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: Website Pro Team
  * Author URI: https://github.com/vendasta/
  * License:

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -65,6 +65,7 @@ class Controller {
 		$this->storage        = DataStorage::instance();
 		$this->registered     = false;
 		$this->profile_fields = array(
+		    new ContactEmail( $this->storage ),
 			new CompanyName( $this->storage ),
 			new FullAddress( $this->storage ),
 			new Address( $this->storage ),

--- a/includes/class-controller.php
+++ b/includes/class-controller.php
@@ -5,6 +5,7 @@ namespace BusinessProfileRender;
 defined( 'ABSPATH' ) || exit;
 require_once( BUSINESS_PROFILE_RENDER_INCLUDE_PATH . 'access-control.php' );
 require_once( BUSINESS_PROFILE_RENDER_INCLUDE_PATH . 'class-data-storage.php' );
+require_once( BUSINESS_PROFILE_RENDER_INCLUDE_PATH . 'profile-fields/class-contact-email.php' );
 require_once( BUSINESS_PROFILE_RENDER_INCLUDE_PATH . 'profile-fields/class-company-name.php' );
 require_once( BUSINESS_PROFILE_RENDER_INCLUDE_PATH . 'profile-fields/class-full-address.php' );
 require_once( BUSINESS_PROFILE_RENDER_INCLUDE_PATH . 'profile-fields/class-address.php' );

--- a/includes/class-data-storage.php
+++ b/includes/class-data-storage.php
@@ -16,6 +16,7 @@
  * "state": "NY",
  * "zip": "10001",
  * "country": "US",
+ * "contact_email": "email@email.com",
  * "work_number": [
  * "234-567-8901",
  * "(432) 343-2132",

--- a/includes/profile-fields/class-contact-email.php
+++ b/includes/profile-fields/class-contact-email.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BusinessProfileRender;
+
+defined( 'ABSPATH' ) || exit;
+require_once( 'class-profilefield.php' );
+
+/**
+ * Class ContactEmail holds and displays the name of the company
+ * Like "Business Incorporated"
+ */
+class ContactEmail extends ProfileField {
+
+    /**
+     * @return  string the name of the datum containing relevant data
+     */
+    protected static function profile_option_name(): string {
+        return "contact_email";
+    }
+
+    /**
+     * @return  string the name of this datum as read by a person
+     */
+    protected static function readable_profile_option(): string {
+        return "Email";
+    }
+
+    /**
+     * @return string the meaningful description of this datum as read by a person
+     */
+    protected static function readable_description(): string {
+        return "The contact email of the business.";
+    }
+}


### PR DESCRIPTION
There's currently no way to update the contact email through the UI, so it's shown as empty now.
![Screen Shot 2020-11-12 at 11 12 07 AM](https://user-images.githubusercontent.com/28071314/98972544-2ce9fc80-24d8-11eb-9f77-16459cee04b1.png)

@vendasta/colonelpanic 